### PR TITLE
Upgrade gnupg and refine scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,30 +14,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+FROM debian:buster
 
 LABEL maintainer="urpylka@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Update APT repository & install packages (except aptly)
+RUN apt-get -q update \
+  && apt-get -y install \
+    bzip2 \
+    gnupg2 \
+    gpgv \
+    graphviz \
+    supervisor \
+    nginx \
+    wget \
+    curl \
+    xz-utils \
+    apt-utils \
+    bash-completion
+
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C \
   && echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list
 
-# Update APT repository & install packages
+# Install aptly package
 RUN apt-get -q update \
-  && apt-get -y install \
-    aptly=1.4.0 \
-    bzip2 \
-    gnupg=1.4.20-1ubuntu3.3 \
-    gpgv=1.4.20-1ubuntu3.3 \
-    graphviz=2.38.0-12ubuntu2.1 \
-    supervisor=3.2.0-2ubuntu0.2 \
-    nginx=1.10.3-0ubuntu0.16.04.5 \
-    wget \
-    curl \
-    xz-utils=5.1.1alpha+20120614-2ubuntu2 \
-    apt-utils \
-    bash-completion \
+  && apt-get -y install aptly=1.4.0 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -46,12 +49,11 @@ RUN rm /etc/nginx/sites-enabled/*
 
 # Create volume
 VOLUME [ "/opt/aptly" ]
-RUN ln -s /opt/aptly/gpg /root/.gnupg
+ENV GNUPGHOME="/opt/aptly/gpg"
 # Allow use nginx wo initial procedure of GPG
 RUN mkdir -p /opt/aptly/public
 
 # Install configurations
-COPY assets/gpg.conf /root/.gnupg/gpg.conf
 COPY assets/aptly.conf /etc/aptly.conf
 COPY assets/nginx.conf /etc/nginx/conf.d/default.conf
 COPY assets/supervisord.web.conf /etc/supervisor/conf.d/web.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:xenial
 
 LABEL maintainer="urpylka@gmail.com"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C \
   && echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,6 @@ RUN rm /etc/nginx/sites-enabled/*
 # Create volume
 VOLUME [ "/opt/aptly" ]
 ENV GNUPGHOME="/opt/aptly/gpg"
-# Allow use nginx wo initial procedure of GPG
-RUN mkdir -p /opt/aptly/public
 
 # Install configurations
 COPY assets/aptly.conf /etc/aptly.conf

--- a/assets/aptly.conf
+++ b/assets/aptly.conf
@@ -9,6 +9,7 @@
   "dependencyFollowSource": false,
   "gpgDisableSign": false,
   "gpgDisableVerify": false,
+  "gpgProvider": "gpg2",
   "downloadSourcePackages": false,
   "ppaDistributorID": "ubuntu",
   "ppaCodename": "",

--- a/assets/gpg.conf
+++ b/assets/gpg.conf
@@ -1,7 +1,0 @@
-# More samples:
-# https://gist.github.com/jbouse/2635431
-# https://gist.github.com/atErik/1a495624a5f03e3fe499
-
-personal-digest-preferences SHA256
-cert-digest-algo SHA256
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed

--- a/assets/keys_gen.sh
+++ b/assets/keys_gen.sh
@@ -5,14 +5,14 @@
 
 # Use: keys_gen.sh <FULL_NAME> <EMAIL_ADDRESS> <GPG_PASSPHRASE>
 
-[[ -z ${1} ]] && exit 1;
-[[ -z ${2} ]] && exit 1;
-[[ -z ${3} ]] && exit 1;
-
 # https://stackoverflow.com/questions/4437573/bash-assign-default-value
 : ${FULL_NAME:=${1}}
 : ${EMAIL_ADDRESS:=${2}}
 : ${GPG_PASSPHRASE:=${3}}
+
+[[ -z ${FULL_NAME} ]] && { echo "FULL_NAME wasn't specified"; exit 1; }
+[[ -z ${EMAIL_ADDRESS} ]] && { echo "EMAIL_ADDRESS wasn't specified"; exit 1; }
+[[ -z ${GPG_PASSPHRASE} ]] && { echo "GPG_PASSPHRASE wasn't specified"; exit 1; }
 
 # If the repository GPG keypair doesn't exist, create it.
 if [[ ! -d /opt/aptly/gpg/private-keys-v1.d/ ]] || [[ ! -f /opt/aptly/gpg/pubring.kbx ]]; then

--- a/assets/keys_gen.sh
+++ b/assets/keys_gen.sh
@@ -30,12 +30,15 @@ else
 fi
 
 # If the repository public key doesn't exist, export it.
-if [[ ! -d /opt/aptly/public ]] || [[ ! -f /opt/aptly/public/repo_signing.key ]]; then
+if [[ ! -d /opt/aptly/public ]] || 
+   [[ ! -f /opt/aptly/public/repo_signing.key ]] ||
+   [[ ! -f /opt/aptly/public/repo_signing.gpg ]]; then
   echo "Export the GPG public keys"
   mkdir -p /opt/aptly/public
   # Export only all public keys,
   # for export private keys use --export-secret-keys
   gpg2 --export --armor > /opt/aptly/public/repo_signing.key
+  gpg2 --export > /opt/aptly/public/repo_signing.gpg
 else
   echo "No need to export the GPG keys"
 fi

--- a/assets/keys_imp.sh
+++ b/assets/keys_imp.sh
@@ -10,17 +10,16 @@
 # Import keyrings if they exist
 if [[ -f ${1} ]]; then
   # Export all public keys from a keyring or a key
-  # ${1} to /opt/aptly/gpg/trustedkeys.gpg
+  # ${1} to $GNUPGHOME/trustedkeys.gpg
 
   I=${1}
-  O="/opt/aptly/gpg/trustedkeys.gpg"
 
-  # gpg --no-options --no-default-keyring --keyring ${O} --keyserver pool.sks-keyservers.net --recv-keys 9D6D8F6BC857C906 AA8E81B4331F7F50
+  # gpg2 --no-options --no-default-keyring --keyring trustedkeys.gpg  --keyserver pool.sks-keyservers.net --recv-keys 9D6D8F6BC857C906 AA8E81B4331F7F50
   # wget -O - http://repo.coex.space/aptly_repo_signing.key | \
-  # gpg --no-options --no-default-keyring --keyring "/opt/aptly/gpg/trustedkeys.gpg" --import
+  # gpg2 --no-options --no-default-keyring --keyring trustedkeys.gpg  --import
 
-  gpg --no-options --no-default-keyring --keyring ${I} --export | \
-  gpg --no-options --no-default-keyring --keyring ${O} --import
+  gpg2 --no-options --no-default-keyring --keyring ${I} --export | \
+  gpg2 --no-options --no-default-keyring --keyring trustedkeys.gpg  --import
 
-  # gpg --no-options --no-default-keyring --keyring ${O} --list-keys
+  # gpg2 --no-options --no-default-keyring --keyring trustedkeys.gpg  --list-keys
 fi

--- a/assets/update_mirror.sh
+++ b/assets/update_mirror.sh
@@ -98,10 +98,5 @@ for snap in ${SNAPSHOTARRAY[@]}; do
 done
 set -e
 
-# Export the all GPG Public keys
-if [[ ! -f /opt/aptly/public/repo_signing.key ]]; then
-  gpg --export --armor > /opt/aptly/public/repo_signing.key
-fi
-
 # Generate Aptly Graph
 aptly graph -output /opt/aptly/public/aptly_graph.png

--- a/assets/update_mirror.sh
+++ b/assets/update_mirror.sh
@@ -44,6 +44,46 @@ DISTS=( buster )
 COMPONENTS=( main contrib non-free rpi )
 ARCH=armhf
 
+# Override repository related variables by options
+
+usage()
+{
+  echo "usage: update-mirror.sh -u $UPSTREAM_URL -r $REPO -d $DISTS -c $COMPONENTS -a $ARCH"
+}
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -u | --upstream-url )
+      shift
+      UPSTREAM_URL="$1"
+      ;;
+    -r | --repo )
+      shift
+      REPO="$1"
+      ;;
+    -d | --dists )
+      shift
+      DISTS=( "$1" )
+      ;;
+    -c | --components )
+      shift
+      COMPONENTS=( "$1" )
+      ;;
+    -a | --arch )
+      shift
+      ARCH="$1"
+      ;;
+    -h | --help )
+      usage
+      exit
+      ;;
+    * )
+      usage
+      exit 1
+  esac
+  shift
+done
+
 # You can specify common options for each aptly command if you need,
 # using the following variables.
 # MIRROR_CREATE_OPTS="-filter=busybox -with-sources"

--- a/assets/update_mirror.sh
+++ b/assets/update_mirror.sh
@@ -23,14 +23,14 @@ set -e
 # COMPONENTS=( main universe )
 # ARCH=amd64
 
-# The variables (as set below) will create a mirror of the Debian Jessie repo
+# The variables (as set below) will create a mirror of the Debian Buster repo
 # with the main and update components. If you do mirror these, you'll want to
-# include "deb http://security.debian.org jessie/updates main" in your sources.list
+# include "deb http://security.debian.org buster/updates main" in your sources.list
 # file or mirror it similarly as done below to keep up with security updates.
 
 # UPSTREAM_URL="http://deb.debian.org/debian/"
 # REPO=debian
-# OS_RELEASE=jessie
+# OS_RELEASE=buster
 # DISTS=( ${OS_RELEASE} ${OS_RELEASE}-updates )
 # COMPONENTS=( main )
 # ARCH=amd64


### PR DESCRIPTION
This PR includes the following changes.

* Upgrade the default distro or packages
  * Use Debian buster which is the current stable version
  * Support gnupg v2 instead of v1
* Refine scripts like `Dockerfile`, `key_gen.sh`, and `update_mirror.sh`
  * Some of these patches add options or variables so that users can control the behavior of aptly more flexibly

See commit messages for reasons or motivations of each change.