### PR TITLE
assets: update_mirror.sh: Correctly parse dist value from snap

### DIFF
--- a/assets/update_mirror.sh
+++ b/assets/update_mirror.sh
@@ -132,9 +132,8 @@ echo
 # Publish the latest snapshots
 set +e
 for snap in ${SNAPSHOTARRAY[@]}; do
-  snap_name=$(echo ${snap} | awk -F'-' '{print $1" "$2}')
-  dist=$(echo ${snap_name} | awk '{print $2}')
-  aptly publish list -raw | grep "^${snap_name}$"
+  dist=$(echo ${snap} | sed "s/^${REPO}-\(.*\)-[^-]*\$/\1/")
+  aptly publish list -raw | grep "^${REPO} ${dist}$"
   if [[ $? -eq 0 ]]; then
     aptly publish switch \
       ${PUBLISH_SWITCH_OPTS} \


### PR DESCRIPTION
Currently, update_mirror.sh doesn't work for the default Debian repository setting.
Please see the commit message for more details about the issue.

I tested with the following command then confirmed that repositories are published correctly.

Debian buster:
```
MIRROR_CREATE_OPTS="-filter=hello -filter-with-deps -with-sources" /opt/update_mirror.sh \
  -u http://deb.debian.org/debian/ \
  -r debian \
  -d "buster buster-updates" \
  -c "main" \
  -a amd64
```

I attached two aptly graphs generated by `update-mirror.sh` ; before & after apply this fix.

Before:
![aptly_graph_bug](https://user-images.githubusercontent.com/11436224/101486827-97d80780-39a0-11eb-80fd-51644afa1792.png)

After:
![aptly_graph_fix](https://user-images.githubusercontent.com/11436224/101486835-9b6b8e80-39a0-11eb-9f7f-f4cbb8f98157.png)

