### PR TITLE
Change keyserver from SKS to Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -q update \
     apt-utils \
     bash-completion
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED75B5A4483DA07C \
   && echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list
 
 # Install aptly package


### PR DESCRIPTION
The SKS keyserver pool is deprecated, so for reliable builds another maintained keyserver should be used (we've seen builds fail because the keyserver was unreachable).
Ubuntu maintains another keyserver which seems supported and stable.