### PR TITLE
patch - prevent lock contention between cli and api server

### DIFF
--- a/assets/supervisord.web.conf
+++ b/assets/supervisord.web.conf
@@ -6,7 +6,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:aptly-api]
-command=/usr/bin/aptly api serve -listen=:8080
+command=/usr/bin/aptly api serve -listen=:8080 -no-lock
 environment=GIN_MODE=release
 redirect_stderr=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
When the docker stack is running for some time, the db get's
unresponsive for cli invocated commands.

The problem is known and also already documented by aptly
https://www.aptly.info/doc/api/

It's caused by lock contention of indepentently running aptly processes.