### PR TITLE
assets: update_mirror.sh: fix aptly mirror update message

### DIFF
--- a/assets/update_mirror.sh
+++ b/assets/update_mirror.sh
@@ -103,7 +103,7 @@ set -e
 
 # Update the all repository mirrors
 for dist in ${DISTS[@]}; do
-  echo "Updating ${REPO} repository mirror.."
+  echo "Updating ${REPO}-${dist} repository mirror.."
   aptly mirror update ${REPO}-${dist}
 done
 


### PR DESCRIPTION
The aptly mirror update message was not showing the
distribution name (e.g. buster, bullseye, etc)

Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>