### PR TITLE
install aptly 1.6.0 on debian bookworm

### DIFF
--- a/assets/keys_gen.sh
+++ b/assets/keys_gen.sh
@@ -24,7 +24,7 @@ if [[ ! -d /opt/aptly/gpg/private-keys-v1.d/ ]] || [[ ! -f /opt/aptly/gpg/pubrin
 
   # If your system doesn't have a lot of entropy this may, take a long time
   # Google how-to create "artificial" entropy, if this gets stuck
-  gpg2 --batch --passphrase "${GPG_PASSPHRASE}" --quick-gen-key "${FULL_NAME} <${EMAIL_ADDRESS}>" default default 0
+  gpg --batch --passphrase "${GPG_PASSPHRASE}" --quick-gen-key "${FULL_NAME} <${EMAIL_ADDRESS}>" default default 0
 else
   echo "No need to generate the new GPG keypair"
 fi
@@ -37,8 +37,8 @@ if [[ ! -d /opt/aptly/public ]] ||
   mkdir -p /opt/aptly/public
   # Export only all public keys,
   # for export private keys use --export-secret-keys
-  gpg2 --export --armor > /opt/aptly/public/repo_signing.key
-  gpg2 --export > /opt/aptly/public/repo_signing.gpg
+  gpg --export --armor > /opt/aptly/public/repo_signing.key
+  gpg --export > /opt/aptly/public/repo_signing.gpg
 else
   echo "No need to export the GPG keys"
 fi


### PR DESCRIPTION
I saw you updated to aptly 1.6.0, but the pipeline failed, as we changed the repos.

This change includes the following:
- based on debian:bookworm-slim
- install from new repos
- cleanup and reduce image size