### PR TITLE
chore: Update aptly to 1.6.2

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   IMAGE_NAME: aptly
-  VER_APTLY: 1.6.1
+  VER_APTLY: 1.6.2
 
 jobs:
   # Run tests.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,5 +5,5 @@ services:
       context: ./
       dockerfile: Dockerfile
       args:
-        VER_APTLY: 1.6.1
+        VER_APTLY: 1.6.2
     command: /opt/run_tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ services:
 
   aptly:
     container_name: aptly
-    image: aptly:1.6.1
+    image: aptly:1.6.2
     build:
       context: ./
       dockerfile: Dockerfile
       args:
-        VER_APTLY: 1.6.1
+        VER_APTLY: 1.6.2
     restart: always
     ports:
       - 80:80


### PR DESCRIPTION
Upstream changelog: https://github.com/aptly-dev/aptly/releases/tag/v1.6.2

Closes: #25 