### PR TITLE
Add renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "docker:pinDigests"],
+  "packageRules": [
+    {
+      "matchFileNames": [".github/workflows/**"],
+      "pinDigests": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a configuration for the [Renovate Bot App](https://github.com/apps/renovate), which does:

* Create PRs against your default branch
* Update you workflows dependencies (implicitly), but do NOT pin to digest them (explicitly)
* Update you Docker dependencies (implicitly), but do pin to digest them (explicitly)

Beside keeping track of your workflow dependencies, this allows you also to track updates on your baseimage and rebuild your image by merging the PR.

You can have a look at what Renovate Bot would actually create:

* [Dependency Dashboard](https://github.com/waja/docker-aptly/issues/5) issue
* [chore(deps): update actions/checkout action to v4](https://github.com/waja/docker-aptly/pull/4)
* [chore(deps): pin debian docker tag to 2424c18](https://github.com/waja/docker-aptly/pull/3)

You just need merge this PR and activate the [Renovate Bot App](https://github.com/apps/renovate) for this repository.