### PR TITLE
Change CMD to use JSON array

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,6 @@ EXPOSE 80 8080
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
 # Start Supervisor when container starts (It calls nginx)
-CMD /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
 
 WORKDIR /opt/aptly


### PR DESCRIPTION
When CMD is written as a shell string, Docker/Podman wraps it in /bin/sh -c "...". This means that when a `podman compose down` or `podman stop` is issued, the SIGTERM hits the outer /bin/sh where it is not handled, Docker/Podman then waits until stop_grace_period expires, where it then issues a SIGKILL. This has the possibility of being bad for the leveldb. As such, this fix allows for the SIGTERM to be properly handled by PID 1.